### PR TITLE
passport@^0.3.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "shortid": "^2.1.2"
   },
   "nbbpm": {
-    "compatibility": "^0.6.0"
+    "compatibility": "^0.6.0 || ^0.7.0 || ^0.8.0"
   },
   "homepage": "https://github.com/joe1chen/nodebb-plugin-sso-instagram",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/joe1chen/nodebb-plugin-sso-instagram/issues"
   },
   "dependencies": {
-    "passport-instagram": "^0.1.2",
+    "passport-instagram": "1.0.0",
     "shortid": "^2.1.2"
   },
   "nbbpm": {


### PR DESCRIPTION
NodeBB core recently updated to v0.3.0 of passport, and with it brings a breaking change that is resolved in this plugin by updating the underlying passport-instagram dependency.
